### PR TITLE
feat: add project context footer to todo app

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -116,6 +116,29 @@ export default function Page() {
           </div>
         )}
       </div>
+
+      {/* Project context */}
+      <p className="mt-10 text-center text-xs text-gray-400">
+        Part of an{" "}
+        <a
+          href="https://github.com/dcow/ai-day-agentic-triage-fix"
+          className="underline hover:text-gray-500"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          AI Day example project
+        </a>{" "}
+        demonstrating agentic GitHub issue triage.{" "}
+        <a
+          href="/slides.pdf"
+          className="underline hover:text-gray-500"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          View slides
+        </a>
+        .
+      </p>
     </main>
   );
 }


### PR DESCRIPTION
Closes #26

**Enhancement:** adds a subtle footer below the todo card linking to the GitHub project and slides PDF, with a brief note that this is part of an AI Day agentic triage demo.

**Implementation:** one new `<p>` element in `app/page.tsx`, positioned outside the max-width card with muted `text-xs text-gray-400` styling and two underlined links (`AI Day example project` → GitHub repo, `View slides` → `/slides.pdf`).




> Generated by [Issue Triage & Auto-Implement Agent](https://github.com/dcow/ai-day-agentic-triage-fix/actions/runs/22746040796) for issue #26 · [◷](https://github.com/search?q=repo%3Adcow%2Fai-day-agentic-triage-fix+%22gh-aw-workflow-id%3A+triage-and-implement%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Triage & Auto-Implement Agent, engine: claude, id: 22746040796, workflow_id: triage-and-implement, run: https://github.com/dcow/ai-day-agentic-triage-fix/actions/runs/22746040796 -->

<!-- gh-aw-workflow-id: triage-and-implement -->