### PR TITLE
feat: add project context footer to todo app

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -116,6 +116,28 @@ export default function Page() {
           </div>
         )}
       </div>
+      <footer className="mt-16 text-center text-xs text-gray-400">
+        <p>
+          Part of an{" "}
+          <a
+            href="https://github.com/dcow/ai-day-agentic-triage-fix"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline hover:text-gray-600"
+          >
+            AI day agentic triage demo
+          </a>
+          {" · "}
+          <a
+            href="/slides.pdf"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline hover:text-gray-600"
+          >
+            view slides
+          </a>
+        </p>
+      </footer>
     </main>
   );
 }


### PR DESCRIPTION
Closes #34

**Enhancement:** adds a subtle footer linking back to the GitHub project and the slides PDF so visitors understand the app's purpose.

**Implementation:** appended a small `(footer)` element below the todo widget in `app/page.tsx` with two inline links styled in muted gray text.




> Generated by [Issue Triage & Auto-Implement Agent](https://github.com/dcow/ai-day-agentic-triage-fix/actions/runs/22747221675) for issue #34 · [◷](https://github.com/search?q=repo%3Adcow%2Fai-day-agentic-triage-fix+%22gh-aw-workflow-id%3A+triage-and-implement%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Triage & Auto-Implement Agent, engine: claude, id: 22747221675, workflow_id: triage-and-implement, run: https://github.com/dcow/ai-day-agentic-triage-fix/actions/runs/22747221675 -->

<!-- gh-aw-workflow-id: triage-and-implement -->