### PR TITLE
fix: correct off-by-one in items left count

### DIFF
--- a/lib/todos.test.ts
+++ b/lib/todos.test.ts
@@ -36,10 +36,15 @@ describe("countRemaining", () => {
     expect(countRemaining([])).toBe(0);
   });
 
-  // known bug: loop starts at i=1, skips first todo
-  it.fails("counts all todos when none are completed", () => {
+  it("counts all todos when none are completed", () => {
     const todos = [createTodo(1, "a"), createTodo(2, "b"), createTodo(3, "c")];
     expect(countRemaining(todos)).toBe(3);
+  });
+
+  // this test would have failed before this fix
+  it("counts a single incomplete todo as 1 item remaining", () => {
+    const todos = [createTodo(1, "only item")];
+    expect(countRemaining(todos)).toBe(1);
   });
 
   it("excludes completed todos from the count", () => {

--- a/lib/todos.ts
+++ b/lib/todos.ts
@@ -16,7 +16,7 @@ export function filterTodos(todos: Todo[], mode: FilterMode): Todo[] {
 // Returns the number of remaining (incomplete) todos.
 export function countRemaining(todos: Todo[]): number {
   let count = 0;
-  for (let i = 1; i < todos.length; i++) {
+  for (let i = 0; i < todos.length; i++) {
     if (!todos[i].completed) count++;
   }
   return count;


### PR DESCRIPTION
Closes #42

**Root cause:** `countRemaining` started its loop at index `1`, silently skipping the first todo and returning a count one less than the actual number of incomplete items.

**Fix:** Changed the loop initializer from `i = 1` to `i = 0` in `lib/todos.ts`.

**Test:** added a regression test to `lib/todos.test.ts`




> Generated by [Issue Triage & Auto-Implement Agent](https://github.com/dcow/ai-day-agentic-triage-fix/actions/runs/22748565566) for issue #42 · [◷](https://github.com/search?q=repo%3Adcow%2Fai-day-agentic-triage-fix+%22gh-aw-workflow-id%3A+triage-and-implement%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Issue Triage & Auto-Implement Agent, engine: claude, id: 22748565566, workflow_id: triage-and-implement, run: https://github.com/dcow/ai-day-agentic-triage-fix/actions/runs/22748565566 -->

<!-- gh-aw-workflow-id: triage-and-implement -->